### PR TITLE
Add community tool and fix copy/paste

### DIFF
--- a/src/content/docs/Community/Community_Tools.mdx
+++ b/src/content/docs/Community/Community_Tools.mdx
@@ -30,8 +30,6 @@ Here are a couple of tools that we found worth checking out. Please feel free to
   </Card>
     <Card title="Support Companion" icon="apple">
 
-    ![Privileges](https://private-user-images.githubusercontent.com/78877636/331749220-d908bb6a-d7ed-42a6-a5d1-5f500ea24a9c.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjA5NjE2MDMsIm5iZiI6MTcyMDk2MTMwMywicGF0aCI6Ii83ODg3NzYzNi8zMzE3NDkyMjAtZDkwOGJiNmEtZDdlZC00MmE2LWE1ZDEtNWY1MDBlYTI0YTljLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzE0VDEyNDgyM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNiNDllZjgyNWZkYTZlOWE5YmFkNTUwZjcyZTBlYzEzNDJiZDViZmM5MDNiZDQ3NjRiNWU4NmMyOTJlODZkYzQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.4Z2tuAhbedksy0DzBOn_u3JxA2grdrmLfxnDAYeQVdg)
-
     Support Companion is a macOS helper application, designed to empower end-users by providing them with quick and easy access to crucial information and actions. This application is built to streamline a variety of tasks, eliminating the need for extensive searching and complex navigation. Support Companion is equipped with a range of features that enhance user productivity.
 
     <a href="https://github.com/macadmins/SupportCompanion" target="_blank">Download</a>
@@ -41,5 +39,15 @@ Here are a couple of tools that we found worth checking out. Please feel free to
     The Support app is a macOS menu bar app built for users to see basic diagnostic information at a glance and proactively notify them to easily fix small issues. It offers shortcuts to easily access support channels, company resources such as websites, apps or file servers. Natively built with SwiftUI for a modern and native macOS look and feel and customizable to style with your corporate identity.
 
     <a href="https://github.com/root3nl/SupportApp" target="_blank">Download</a>
+  </Card>
+  <Card title="Intune Uploader" icon="apple">
+    Set of AutoPkg processors for uploading and updating apps in Intune.
+
+    <a href="https://github.com/almenscorner/intune-uploader" target="_blank">Download</a>
+  </Card>
+  <Card title="Almenscorner recipes" icon="apple">
+    A set of recipes for use with the IntuneAppUploader processor.
+
+    <a href="https://github.com/autopkg/almenscorner-recipes" target="_blank">Download</a>
   </Card>
 </CardGrid>

--- a/src/content/docs/Community/Community_Tools.mdx
+++ b/src/content/docs/Community/Community_Tools.mdx
@@ -44,10 +44,10 @@ Here are a couple of tools that we found worth checking out. Please feel free to
     Set of AutoPkg processors for uploading and updating apps in Intune.
 
     <a href="https://github.com/almenscorner/intune-uploader" target="_blank">Download</a>
-  </Card>
-  <Card title="Almenscorner recipes" icon="apple">
-    A set of recipes for use with the IntuneAppUploader processor.
 
-    <a href="https://github.com/autopkg/almenscorner-recipes" target="_blank">Download</a>
+     <br />
+
+    Recipes for the Intune Uploader can be found here: 
+    <a href="https://github.com/autopkg/almenscorner-recipes" target="_blank">almenscorner-recipes</a>
   </Card>
 </CardGrid>


### PR DESCRIPTION
Added Intune Uploader and recipes for it to community tools and removed a link to privileges from SupportCompanion which appears to be a copy/paste error.