### PR TITLE
Amend FileVault policy include additional required setting

### DIFF
--- a/src/content/docs/baselinesettings/filevault.mdx
+++ b/src/content/docs/baselinesettings/filevault.mdx
@@ -14,6 +14,7 @@ Click on the link to download the JSON file from <a href="https://github.com/Ski
 
 | Setting                               | Value   |
 |---------------------------------------|---------|
+| Defer | Enabled   |
 | Recovery Key Rotation In Months| 6 months   |
 | Enable  | On   |
 | Force Enable In Setup Assistant | True   |


### PR DESCRIPTION
Added line 17 to include additional required FileVault setting per [MS documentation](https://learn.microsoft.com/en-us/intune/intune-service/protect/encrypt-devices-filevault#enable-filevault-through-the-setup-assistant).

MS's documentation (screenshot attached below) is a bit vague about whether or not this is required: it says the **Defer** must be enabled for devices running macOS 14.4, but I think it would be more appropriate to say that this applies to devices running 14.4 *and later*.

<img width="834" height="148" alt="filevault" src="https://github.com/user-attachments/assets/b2972a75-16a6-4f5e-8ae1-ecc1fc71d025" />

I've done some testing enrolling (ADE) a MacBook Pro running Sequoia 15.6.1 and I wasn't able to get the FileVault recovery key into Intune immediately unless I enabled **Defer**.

If accepted, the [associated JSON file linked to in this page](https://www.intunemacadmins.com/src/assets/FileVault/Enable_FileVault_during_Setup_Assistant.json) would need to be amended.

Thank you for considering this change. Many thanks for all your work--it has been immensely helpful to me.