### PR TITLE
Fix Company Portal download link

### DIFF
--- a/src/content/docs/Complete Guide Macos Deployment/Install_the_Company_Portal_app_for_MacOS_as_a_MacOS_LOB_app.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Install_the_Company_Portal_app_for_MacOS_as_a_MacOS_LOB_app.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 Company Portal for macOS can be downloaded and installed using the macOS LOB apps feature. The version downloaded is the version that will always be installed and may need to be updated periodically to ensure users get the best experience during initial enrollment.
 
-Download Company Portal for macOS from [here](https://go.microsoft.com/fwlink/?linkid=853070?wt.mc_id=MVP_377186)
+Download Company Portal for macOS from [here](https://go.microsoft.com/fwlink/?linkid=853070)
 
 Add the app by going to the Intune portal – Apps – Add – App Type Line-of-business app – select
 


### PR DESCRIPTION
Line 13 contains a URL that does not work; currently, the URL directs you to a Bing homepage.

PR includes commit with fixed URL per [Microsoft documentation](https://learn.microsoft.com/en-us/intune/intune-service/apps/apps-company-portal-macos#install-company-portal-for-macos-as-a-macos-lob-app).