### PR TITLE
Update Gatekeeper policy to disable Finder contextual menu override

### DIFF
--- a/src/content/docs/baselinesettings/gatekeeper.mdx
+++ b/src/content/docs/baselinesettings/gatekeeper.mdx
@@ -6,7 +6,8 @@ description: How to configure Gatekeeper for your Intune tenant.
 import { Steps, Aside } from "@astrojs/starlight/components";
 
 <Aside>
-Click on the link to download the JSON file from <a href="https://github.com/SkipToTheEndpoint/OpenIntuneBaseline/blob/main/MACOS/NativeImport/MacOS%20-%20OIB%20-%20Firewall%20-%20D%20-%20Gatekeeper%20-%20v1.0.json" target="_blank">GitHub</a>
+Click on the link to download the JSON file from <a href="https://github.com/SkipToTheEndpoint/OpenIntuneBaseline/blob/main/MACOS/NativeImport/MacOS%20-%20OIB%20-%20Firewall%20-%20D%20-%20Gatekeeper%20-%20v1.0.json" target="_blank">GitHub</a>.
+- Note: the above JSON file does not currently include the **System Policy Managed** > **Disable Override** payload.
 </Aside>
 
 ## FireWall
@@ -26,3 +27,9 @@ Click on the link to download the JSON file from <a href="https://github.com/Ski
 | Enable XProtect Malware Upload | Disabled |
 | Allow Identified Developers    | True     |
 | Enable Assessment              | True     |
+
+## System Policy Managed
+
+| Setting          | Value |
+|------------------|-------|
+| Disable Override | True  |


### PR DESCRIPTION
The current [Gatekeeper policy](https://github.com/ugurkocde/intunemacadmins/blob/9f9ba87522025cbd23501f8bd78193c92dde22d6/src/content/docs/baselinesettings/gatekeeper.mdx) does not manage the Finder contextual menu override function.

The [Mac Evaluation Utility](https://beta.apple.com/download/1019980) presents a warning when this is not managed, per the following screenshot.

<img width="601" height="1011" alt="gatekeeper" src="https://github.com/user-attachments/assets/10500a43-f059-4909-823a-21c9e70fc7ca" />

(More info is available at https://support.apple.com/en-ca/guide/deployment/dep61dc030/web.)

I've tested adding the requested domain and key (**com.apple.systempolicy.managed** and **DisableOverride**, respectively), and the warning goes away.

(Note for anyone reading this: if using Intune, you can find **DisableOverride** in a macOS configuration policy (Settings Catalog policy type), under **System Policy Managed** > **Disable Override**.)

(Another note: I have also submitted a [feature request](https://github.com/SkipToTheEndpoint/OpenIntuneBaseline/issues/129) to the OpenIntuneBaseline GitHub repo to request that this gets changed upstream.)