### PR TITLE
Run content pipeline on a self-hosted runner

### DIFF
--- a/.github/self-hosted-runner.md
+++ b/.github/self-hosted-runner.md
@@ -1,0 +1,53 @@
+# Self-hosted runner for the content pipeline
+
+The **Content pipeline** workflow runs on a self-hosted runner so it executes
+from a residential IP. This unblocks the two sources that GitHub's datacenter
+IPs get blocked from:
+
+- **Reddit** (public RSS returns HTTP 429 from cloud IPs; works from home — no
+  API credentials needed)
+- **Rockenroll** and any other blog that blocks datacenter IP ranges
+
+The **Docs freshness** and **Link check** workflows stay on GitHub's cloud
+runners (`ubuntu-latest`) — their sources (Microsoft Learn, Apple) are reachable
+from anywhere, so they keep running even if the self-hosted machine is off.
+
+A manual run of the content pipeline can still target the cloud via the
+**runner** input (`ubuntu-latest`) — handy for testing without the runner.
+
+## Requirements on the runner machine
+
+- Always-on (a Mac mini, home server, or Raspberry Pi is ideal; a laptop that's
+  often closed will miss the Monday schedule).
+- macOS or Linux, on your home/office network.
+- Tools on PATH: `git`, `gh` (GitHub CLI), `jq`. Node is provided by the
+  workflow via `actions/setup-node`, but Node 22+ system-wide is a safe backup.
+  - macOS: `brew install gh jq`
+
+`gh` and `jq` are required because the pipeline's "report source failures as
+issues" step uses them (GitHub's cloud runners ship them preinstalled; a
+self-hosted runner does not).
+
+## One-time setup
+
+1. In GitHub: **Settings → Actions → Runners → New self-hosted runner**.
+2. Pick the runner's OS and follow the shown **Download** and **Configure**
+   commands verbatim (they include a one-time registration token). Accept the
+   default labels — they must include `self-hosted`.
+3. Install it as a service so it runs without a terminal and survives reboots:
+   - macOS / Linux: `./svc.sh install && ./svc.sh start`
+4. Confirm it shows **Idle** under Settings → Actions → Runners.
+
+## Verify
+
+- Actions → **Content pipeline** → **Run workflow** with `runner = self-hosted`.
+- The run should fetch Reddit and Rockenroll successfully and open the weekly PR.
+
+## Notes
+
+- If the machine is off when the Monday 06:00 UTC schedule fires, the job queues
+  and runs when the runner next comes online; GitHub cancels it if the runner
+  stays offline past the queue window. Keep the machine on around Mondays.
+- Security: this is safe on a public repo because these workflows trigger only on
+  `schedule` and `workflow_dispatch` — never on `pull_request` from forks — so
+  outside contributors cannot execute code on your runner.

--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -19,6 +19,13 @@ on:
           - tech-community
           - community-blog
           - reddit
+      runner:
+        description: "Where to run (self-hosted = your residential IP; ubuntu-latest = GitHub cloud, Reddit/Rockenroll get IP-blocked)"
+        type: choice
+        default: self-hosted
+        options:
+          - self-hosted
+          - ubuntu-latest
 
 permissions:
   contents: write
@@ -31,7 +38,9 @@ concurrency:
 
 jobs:
   update-content:
-    runs-on: ubuntu-latest
+    # Scheduled runs use the self-hosted runner (residential IP, no source IP
+    # blocks). A manual run can pick the cloud via the `runner` input.
+    runs-on: ${{ github.event.inputs.runner || 'self-hosted' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Points the **Content pipeline** workflow at a self-hosted runner so it runs from your residential IP — unblocking Reddit (RSS is 429-blocked from GitHub's cloud IPs; works from home with no credentials) and blogs that block datacenter ranges (Rockenroll).

- Scheduled runs use `self-hosted`; a manual run can pick `ubuntu-latest` via the new **runner** input (for cloud testing).
- **Docs freshness** and **Link check** stay on the cloud — their sources (Microsoft Learn, Apple) are reachable anywhere, so they keep running even when your runner is off.
- Adds `.github/self-hosted-runner.md` with setup steps and prerequisites (the runner needs `gh` + `jq` installed).

After merge: register a self-hosted runner on an always-on machine (Settings → Actions → Runners → New self-hosted runner) and start it as a service.