### PR TITLE
Ensure gh/jq on PATH for self-hosted runner

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -43,6 +43,14 @@ jobs:
     runs-on: ${{ github.event.inputs.runner || 'self-hosted' }}
     timeout-minutes: 30
     steps:
+      # Self-hosted runners (esp. as a launchd/systemd service) often have a
+      # stripped PATH that omits Homebrew, so gh/jq aren't found. Add the common
+      # locations. No-op on GitHub's cloud runners (dirs absent or already set).
+      - name: Ensure local tools on PATH
+        run: |
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Self-hosted runners running as a launchd/systemd service often have a stripped PATH that omits Homebrew, so the pipeline's `gh`/`jq` step would fail. Prepends the common Homebrew bin dirs to PATH; no-op on GitHub's cloud runners.