### PR TITLE
Reddit via browser User-Agent on the RSS feed (no app, no login)

### DIFF
--- a/scripts/pipeline/config.ts
+++ b/scripts/pipeline/config.ts
@@ -58,6 +58,21 @@ export const REDDIT_SEARCHES = [
     url: "https://oauth.reddit.com/r/macsysadmin/search?q=intune&restrict_sr=1&sort=new&limit=50",
   },
 ] as const;
+// Reddit 429s automation User-Agents but serves its public RSS to a normal
+// browser UA, logged out. Used only for the Reddit RSS feeds (other sources
+// keep the honest USER_AGENT above).
+export const REDDIT_RSS_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+  Accept: "application/rss+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.9",
+};
+
+// Reddit rate-limits bursts even with a browser UA, so retry 429s with long
+// waits and space the two feeds apart. Low weekly volume makes this reliable.
+export const REDDIT_RSS_BACKOFF_MS = [8000, 20000];
+export const REDDIT_RSS_FEED_GAP_MS = 5000;
+
 export const REDDIT_RSS_SEARCHES = [
   {
     sourceName: "r/Intune",

--- a/scripts/pipeline/fetch/http.ts
+++ b/scripts/pipeline/fetch/http.ts
@@ -20,6 +20,9 @@ interface FetchOptions {
   body?: string;
   timeoutMs?: number;
   retries?: number;
+  // Per-attempt backoff in ms; falls back to HTTP_BACKOFF_MS. Used to give
+  // rate-limit-prone sources (Reddit) much longer waits between 429 retries.
+  backoffMs?: number[];
 }
 
 export async function fetchWithRetry(
@@ -27,6 +30,7 @@ export async function fetchWithRetry(
   options: FetchOptions = {},
 ): Promise<Response> {
   const retries = options.retries ?? HTTP_RETRIES;
+  const backoff = options.backoffMs ?? HTTP_BACKOFF_MS;
   let lastError: unknown;
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
@@ -49,7 +53,7 @@ export async function fetchWithRetry(
       lastError = error;
       if (attempt >= retries) break;
     }
-    await sleep(HTTP_BACKOFF_MS[Math.min(attempt, HTTP_BACKOFF_MS.length - 1)]);
+    await sleep(backoff[Math.min(attempt, backoff.length - 1)]);
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }

--- a/scripts/pipeline/fetch/reddit.ts
+++ b/scripts/pipeline/fetch/reddit.ts
@@ -3,6 +3,9 @@ import {
   EXCERPT_MAX_CHARS,
   ITEM_WINDOW_DAYS,
   REDDIT_MIN_SCORE,
+  REDDIT_RSS_BACKOFF_MS,
+  REDDIT_RSS_FEED_GAP_MS,
+  REDDIT_RSS_HEADERS,
   REDDIT_RSS_SEARCHES,
   REDDIT_SEARCHES,
   REDDIT_TOKEN_URL,
@@ -11,7 +14,7 @@ import {
 import { canonicalUrl, hashId } from "../state";
 import { normalizeWhitespace, truncate } from "../text";
 import type { RawItem } from "../types";
-import { fetchJson, fetchText, fetchWithRetry } from "./http";
+import { fetchJson, fetchText, fetchWithRetry, sleep } from "./http";
 import { parseFeed } from "./rss";
 
 interface RedditPost {
@@ -52,37 +55,63 @@ async function getAccessToken(): Promise<string> {
   return data.access_token;
 }
 
-// Credential-free fallback: public search.rss feeds (Atom). No score data, so
-// the LLM classifier is the only quality gate; the reused feed parser handles
-// the rest. Reddit strips the post body down to an HTML snippet that ends in
-// "submitted by /u/author [link] [comments]" boilerplate, removed here.
+// Credential-free, no-login access to Reddit's public search.rss feeds (Atom).
+// Reddit returns 429 to bot/automation User-Agents but serves the public RSS
+// fine to a normal browser UA - so we send one here (and only here). No score
+// data, so the LLM classifier is the only quality gate; the reused feed parser
+// handles the rest. Reddit ends each post body with a "submitted by /u/author
+// [link] [comments]" boilerplate, removed below.
 export async function fetchRedditViaRss(now: Date): Promise<RawItem[]> {
   const cutoff = new Date(now.getTime() - ITEM_WINDOW_DAYS * 86_400_000);
   const items: RawItem[] = [];
   const seen = new Set<string>();
-  for (const search of REDDIT_RSS_SEARCHES) {
-    const xml = await fetchText(search.url);
-    for (const entry of parseFeed(xml)) {
-      if (new Date(entry.publishedAt) < cutoff) continue;
-      const id = hashId(`url:${canonicalUrl(entry.url)}`);
-      if (seen.has(id)) continue;
-      seen.add(id);
-      const body = entry.text
-        .replace(/\s*submitted by\s+\/u\/\S+[\s\S]*$/i, "")
-        .trim();
-      items.push({
-        id,
-        source: "reddit",
-        sourceName: search.sourceName,
-        url: entry.url,
-        title: entry.title,
-        author: entry.author ? entry.author.replace(/^\//, "") : undefined,
-        publishedAt: entry.publishedAt,
-        excerpt: truncate(body, EXCERPT_MAX_CHARS),
-        content: truncate(body, CONTENT_MAX_CHARS),
-        meta: { via: "rss" },
+  const failures: string[] = [];
+
+  for (let f = 0; f < REDDIT_RSS_SEARCHES.length; f++) {
+    const search = REDDIT_RSS_SEARCHES[f];
+    // Space requests out: Reddit rate-limits bursts even with a browser UA.
+    if (f > 0) await sleep(REDDIT_RSS_FEED_GAP_MS);
+    try {
+      const xml = await fetchText(search.url, {
+        headers: REDDIT_RSS_HEADERS,
+        retries: REDDIT_RSS_BACKOFF_MS.length,
+        backoffMs: REDDIT_RSS_BACKOFF_MS,
       });
+      for (const entry of parseFeed(xml)) {
+        if (new Date(entry.publishedAt) < cutoff) continue;
+        const id = hashId(`url:${canonicalUrl(entry.url)}`);
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const body = entry.text
+          .replace(/\s*submitted by\s+\/u\/\S+[\s\S]*$/i, "")
+          .trim();
+        items.push({
+          id,
+          source: "reddit",
+          sourceName: search.sourceName,
+          url: entry.url,
+          title: entry.title,
+          author: entry.author ? entry.author.replace(/^\//, "") : undefined,
+          publishedAt: entry.publishedAt,
+          excerpt: truncate(body, EXCERPT_MAX_CHARS),
+          content: truncate(body, CONTENT_MAX_CHARS),
+          meta: { via: "rss" },
+        });
+      }
+    } catch (error) {
+      // Isolate per feed: a 429 on one subreddit must not discard the others.
+      failures.push(
+        `${search.sourceName}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
+  }
+
+  // Only treat the source as failed (-> soft skip) if every feed failed.
+  if (items.length === 0 && failures.length === REDDIT_RSS_SEARCHES.length) {
+    throw new Error(failures.join("; "));
+  }
+  if (failures.length > 0) {
+    console.error(`  reddit: ${failures.length} feed(s) rate-limited this run: ${failures.join("; ")}`);
   }
   return items;
 }


### PR DESCRIPTION
Reddit serves its public search RSS to a normal browser User-Agent — no login, no API app, no browser automation. The pipeline was sending a bot UA and getting 429'd; now it sends a browser UA **only for the Reddit RSS feeds** (other sources keep the honest UA).

Also makes Reddit resilient to Reddit's per-IP burst rate-limiting: each subreddit feed is fetched independently (one feed's 429 no longer discards the other), with long 429 backoff and spacing between feeds. At weekly volume (two cold requests from the self-hosted runner's residential IP) this is reliable; a transient throttle gracefully skips one feed instead of all.

Verified the UA unlock directly: `r/Intune/search.rss` returns 25 entries with a browser UA where the bot UA returned 429. (Couldn't show a full clean run at commit time because rapid testing rate-limited my own IP — the cold weekly run is the real test.)