### PR TITLE
Structured data, robots.txt, and llms.txt for SEO + GEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
       plugins: [starlightImageZoom()],
       title: "IntuneMacAdmins",
       components: {
+        Head: "./src/components/Head.astro",
         LastUpdated: "./src/components/LastUpdated.astro",
         ThemeProvider: "./src/components/ThemeProvider.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,46 @@
+# IntuneMacAdmins
+
+> Community-driven guides, scripts, tools and best practices for managing Apple macOS devices with Microsoft Intune. Written for IT admins, the site covers enrollment and Automated Device Enrollment (ADE/ABM), Platform Single Sign-On (PSSO), FileVault, Declarative Device Management (DDM), Microsoft Defender for Endpoint, OneDrive Known Folder Move, baseline configuration, troubleshooting and more.
+
+## Start here
+
+- [Getting Started](https://intunemacadmins.com/home/getting_started/): Overview of the site and how to begin managing macOS with Intune.
+- [Frequently Asked Questions](https://intunemacadmins.com/frequently-asked-questions/faq/): Answers on VPP, APNs and enrollment tokens, user vs. device assignments, updates, Defender onboarding, certificates and more.
+- [How to Contribute](https://intunemacadmins.com/home/how_to_contribute/): How the community adds and improves guides.
+
+## Core guides
+
+- [Prerequisites for macOS management](https://intunemacadmins.com/intune-getting-started-guide/prerequisites/): Licenses, roles, enrollment restrictions and Apple certificates needed before managing macOS with Intune.
+- [Basic tenant setup](https://intunemacadmins.com/intune-getting-started-guide/basic_tenant_setup/): Core Intune tenant configuration for macOS.
+- [Apple Business Manager](https://intunemacadmins.com/complete-guide-macos-deployment/apple_business_manager/): Start of the end-to-end guide to deploying and enrolling macOS devices via ABM and Automated Device Enrollment.
+- [What is Platform Single Sign-On (PSSO)?](https://intunemacadmins.com/platform-single-sign-on/what_is_psso/): Platform SSO for macOS, including Secure Enclave vs. Password methods and security considerations.
+- [Configure Platform SSO](https://intunemacadmins.com/platform-single-sign-on/configure_psso/): Step-by-step PSSO configuration in Intune.
+- [Baseline Settings for Intune](https://intunemacadmins.com/baselinesettings/settingsoverview/): A ready-to-import macOS baseline covering Platform SSO, antivirus, Defender, accounts and login, restrictions, FileVault, Gatekeeper, Edge, Office, OneDrive and updates.
+
+## Security and configuration
+
+- [What is FileVault?](https://intunemacadmins.com/filevault/what_is_filevault/): Configuring and managing FileVault disk encryption on macOS with Intune.
+- [What is Declarative Device Management (DDM)?](https://intunemacadmins.com/declarative-device-management/what_is_declarative_device_management/): Using DDM for macOS, including software update enforcement.
+- [What are Custom Attributes?](https://intunemacadmins.com/custom-attributes/what_are_custom_attributes/): Collecting custom device attributes from macOS with shell scripts.
+- [What is Await Final Configuration?](https://intunemacadmins.com/await-final-configuration/what_is_await_final_configuration/): Holding the macOS Setup Assistant until configuration is applied.
+- [Enroll macOS in Microsoft Defender](https://intunemacadmins.com/complete-guide-macos-deployment/enroll_macos_in_microsoft_defender/): Onboarding managed Macs to Microsoft Defender for Endpoint.
+
+## Apps and data
+
+- [What is Microsoft AutoUpdate (MAU)?](https://intunemacadmins.com/updating-microsoft-apps/microsoft_auto_update/): Keeping Microsoft apps current on macOS via Microsoft AutoUpdate.
+- [How to update Microsoft apps](https://intunemacadmins.com/updating-microsoft-apps/how_to_update_microsoft_apps/): Configuring update behavior for Microsoft apps on macOS.
+- [What is OneDrive Known Folder Move (KFM)?](https://intunemacadmins.com/onedrive-known-folder-move-kfm/what_is_onedrive_kfm/): Redirecting and backing up known folders to OneDrive on macOS.
+- [How to deploy files on a Mac](https://intunemacadmins.com/deploy-files/how_to_deploy_files/): Packaging and deploying files such as license files to managed Macs.
+
+## Operations
+
+- [Enrollment error troubleshooting](https://intunemacadmins.com/troubleshooting/enrollment_error/): Fixing the common macOS enrollment error caused by Apple device platform restrictions.
+- [Packaging snippets](https://intunemacadmins.com/snippets/packaging/): Reusable shell snippets for packaging apps and files for macOS.
+- [Community resources](https://intunemacadmins.com/community/community_resources/): Curated community resources for Intune macOS admins.
+- [Community tools](https://intunemacadmins.com/community/community_tools/): Tools built by the community for managing macOS with Intune.
+
+## Optional
+
+- [Contributors](https://intunemacadmins.com/home/contributors/): The people behind the guides.
+- [Changelog](https://intunemacadmins.com/home/changelog/): Recent changes to the site.
+- [GitHub repository](https://github.com/ugurkocde/intunemacadmins): Source for the site and all guides.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,73 @@
+# robots.txt for https://intunemacadmins.com
+# Community guides, tools and best practices for managing macOS with Microsoft Intune.
+
+# Default: allow all standard search and web crawlers full access.
+User-agent: *
+Allow: /
+
+# AI / answer-engine crawlers are explicitly welcome.
+# We want our macOS + Intune guidance to be discoverable and citable by
+# generative engines (ChatGPT, Perplexity, Gemini, Copilot, Claude, etc.).
+
+# OpenAI
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+# Anthropic
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Perplexity
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# Google (Gemini / Vertex AI training and grounding)
+User-agent: Google-Extended
+Allow: /
+
+# Apple Intelligence
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# Microsoft Bing / Copilot
+User-agent: Bingbot
+Allow: /
+
+# Common Crawl (training corpus used by many models)
+User-agent: CCBot
+Allow: /
+
+# Amazon
+User-agent: Amazonbot
+Allow: /
+
+# You.com
+User-agent: YouBot
+Allow: /
+
+# Meta AI
+User-agent: meta-externalagent
+Allow: /
+
+Sitemap: https://intunemacadmins.com/sitemap-index.xml

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,187 @@
+---
+// Custom Head override: renders Starlight's default <head> tags, then injects
+// JSON-LD structured data for SEO and generative-engine optimization (GEO).
+//
+// Schema strategy:
+//   - Every page: BreadcrumbList derived from the URL path.
+//   - Home (splash) page: WebSite + Organization (with sameAs -> GitHub).
+//   - Doc pages: TechArticle with dateModified from lastReviewed/lastUpdated.
+//   - FAQ page: FAQPage built from the page's H2/answer pairs.
+//
+// Route data comes from Astro.locals.starlightRoute (Starlight >= 0.32),
+// never from Astro.props.
+import Default from "@astrojs/starlight/components/Head.astro";
+
+const { entry, lastUpdated, id } = Astro.locals.starlightRoute;
+const data = entry.data;
+
+const site = Astro.site ?? new URL("https://intunemacadmins.com");
+const ORG_NAME = "IntuneMacAdmins";
+const GITHUB_URL = "https://github.com/ugurkocde/intunemacadmins";
+const LOGO_URL = new URL("/IntuneMacAdmins.jpg", site).href;
+
+/** Build a canonical, trailing-slashed absolute URL that matches Starlight's <link rel="canonical">. */
+function pageUrl(pathname: string): string {
+  const url = new URL(pathname, site);
+  if (!url.pathname.endsWith("/")) url.pathname += "/";
+  return url.href;
+}
+
+const canonicalUrl = pageUrl(Astro.url.pathname);
+const isHome = data.template === "splash" || id === "" || id === "index";
+
+// ISO date for dateModified: prefer explicit lastReviewed frontmatter, else
+// Starlight's computed lastUpdated, else undefined (omit the property).
+let dateModified: string | undefined;
+if (typeof data.lastReviewed === "string" && data.lastReviewed) {
+  const d = new Date(data.lastReviewed);
+  if (!isNaN(d.getTime())) dateModified = d.toISOString();
+}
+if (!dateModified && lastUpdated instanceof Date && !isNaN(lastUpdated.getTime())) {
+  dateModified = lastUpdated.toISOString();
+}
+
+// Organization node, reused via @id reference.
+const organization = {
+  "@type": "Organization",
+  "@id": `${site.href}#organization`,
+  name: ORG_NAME,
+  url: site.href,
+  logo: {
+    "@type": "ImageObject",
+    url: LOGO_URL,
+  },
+  sameAs: [GITHUB_URL],
+};
+
+// WebSite node, reused via @id reference.
+const website = {
+  "@type": "WebSite",
+  "@id": `${site.href}#website`,
+  url: site.href,
+  name: ORG_NAME,
+  description:
+    "Community guides, tools and best practices for managing macOS devices with Microsoft Intune.",
+  inLanguage: "en",
+  publisher: { "@id": `${site.href}#organization` },
+};
+
+/** Turn a URL slug segment into a human-readable breadcrumb label. */
+function humanizeSegment(segment: string): string {
+  return decodeURIComponent(segment)
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// BreadcrumbList from the path. Always starts at Home, then one item per
+// path segment, with the final item pointing at the current page.
+const segments = Astro.url.pathname.split("/").filter(Boolean);
+const breadcrumbItems = [
+  {
+    "@type": "ListItem",
+    position: 1,
+    name: "Home",
+    item: site.href,
+  },
+];
+let acc = "";
+segments.forEach((segment, index) => {
+  acc += `/${segment}`;
+  const isLast = index === segments.length - 1;
+  const name = isLast && data.title ? data.title : humanizeSegment(segment);
+  breadcrumbItems.push({
+    "@type": "ListItem",
+    position: index + 2,
+    name,
+    item: pageUrl(acc),
+  });
+});
+
+const breadcrumb = {
+  "@type": "BreadcrumbList",
+  "@id": `${canonicalUrl}#breadcrumb`,
+  itemListElement: breadcrumbItems,
+};
+
+// Per-page primary node.
+const graph: Record<string, unknown>[] = [];
+
+if (isHome) {
+  graph.push(organization, website, breadcrumb);
+} else {
+  const article: Record<string, unknown> = {
+    "@type": "TechArticle",
+    "@id": `${canonicalUrl}#article`,
+    headline: data.title,
+    name: data.title,
+    url: canonicalUrl,
+    mainEntityOfPage: { "@type": "WebPage", "@id": canonicalUrl },
+    inLanguage: "en",
+    isPartOf: { "@id": `${site.href}#website` },
+    author: { "@id": `${site.href}#organization` },
+    publisher: { "@id": `${site.href}#organization` },
+    image: LOGO_URL,
+  };
+  if (data.description) article.description = data.description;
+  if (dateModified) article.dateModified = dateModified;
+
+  graph.push(article, breadcrumb);
+}
+
+// FAQPage: parse "## question" headings followed by their answer text from the
+// raw markdown body. Strip common markdown so the schema text stays clean.
+function stripMarkdown(input: string): string {
+  return input
+    .replace(/```[\s\S]*?```/g, " ") // fenced code blocks
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> text
+    .replace(/`([^`]+)`/g, "$1") // inline code
+    .replace(/[*_~>#]/g, " ") // emphasis/heading/quote markers
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const isFaq = id.toLowerCase().endsWith("frequently-asked-questions/faq");
+if (isFaq && typeof entry.body === "string" && entry.body) {
+  const faqEntries: { question: string; answer: string }[] = [];
+  const sections = entry.body.split(/\n(?=##\s)/);
+  for (const section of sections) {
+    const match = section.match(/^##\s+(.+?)\s*\n([\s\S]*)$/);
+    if (!match) continue;
+    const question = stripMarkdown(match[1].replace(/^\d+\.\s*/, ""));
+    const answer = stripMarkdown(match[2]);
+    if (question && answer) {
+      faqEntries.push({ question, answer });
+    }
+  }
+  if (faqEntries.length > 0) {
+    graph.push({
+      "@type": "FAQPage",
+      "@id": `${canonicalUrl}#faqpage`,
+      mainEntity: faqEntries.map((faq) => ({
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: faq.answer,
+        },
+      })),
+    });
+  }
+}
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": graph,
+};
+---
+
+<Default><slot /></Default>
+
+<script
+  type="application/ld+json"
+  set:html={JSON.stringify(jsonLd)}
+  is:inline
+/>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -30,16 +30,32 @@ function pageUrl(pathname: string): string {
 const canonicalUrl = pageUrl(Astro.url.pathname);
 const isHome = data.template === "splash" || id === "" || id === "index";
 
-// ISO date for dateModified: prefer explicit lastReviewed frontmatter, else
-// Starlight's computed lastUpdated, else undefined (omit the property).
+// ISO date for dateModified: prefer explicit lastReviewed frontmatter (schema
+// coerces it to a Date), else Starlight's computed lastUpdated, else undefined
+// (omit the property).
 let dateModified: string | undefined;
-if (typeof data.lastReviewed === "string" && data.lastReviewed) {
-  const d = new Date(data.lastReviewed);
+const reviewed = data.lastReviewed;
+if (reviewed instanceof Date && !isNaN(reviewed.getTime())) {
+  dateModified = reviewed.toISOString();
+} else if (typeof reviewed === "string" && reviewed) {
+  const d = new Date(reviewed);
   if (!isNaN(d.getTime())) dateModified = d.toISOString();
 }
 if (!dateModified && lastUpdated instanceof Date && !isNaN(lastUpdated.getTime())) {
   dateModified = lastUpdated.toISOString();
 }
+
+// Maintainer (named person) for E-E-A-T: a real, verifiable person behind the
+// site, referenced as the Organization's founder and as the default page author.
+const MAINTAINER_NAME = "Ugur Koc";
+const MAINTAINER_URL = "https://github.com/ugurkocde";
+const person = {
+  "@type": "Person",
+  "@id": `${site.href}#maintainer`,
+  name: MAINTAINER_NAME,
+  url: MAINTAINER_URL,
+  sameAs: [MAINTAINER_URL],
+};
 
 // Organization node, reused via @id reference.
 const organization = {
@@ -51,6 +67,7 @@ const organization = {
     "@type": "ImageObject",
     url: LOGO_URL,
   },
+  founder: { "@id": `${site.href}#maintainer` },
   sameAs: [GITHUB_URL],
 };
 
@@ -109,7 +126,7 @@ const breadcrumb = {
 const graph: Record<string, unknown>[] = [];
 
 if (isHome) {
-  graph.push(organization, website, breadcrumb);
+  graph.push(organization, website, person, breadcrumb);
 } else {
   const article: Record<string, unknown> = {
     "@type": "TechArticle",
@@ -120,7 +137,10 @@ if (isHome) {
     mainEntityOfPage: { "@type": "WebPage", "@id": canonicalUrl },
     inLanguage: "en",
     isPartOf: { "@id": `${site.href}#website` },
-    author: { "@id": `${site.href}#organization` },
+    author:
+      typeof data.author === "string" && data.author
+        ? { "@type": "Person", name: data.author }
+        : { "@id": `${site.href}#organization` },
     publisher: { "@id": `${site.href}#organization` },
     image: LOGO_URL,
   };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,8 +13,13 @@ export const collections = {
         // lastReviewed - ISO date the page was last verified against upstream.
         // sources - authoritative MS/Apple URLs this page is based on, so the
         // freshness checker can diff the page against current ground truth.
-        lastReviewed: z.string().optional(),
+        // Coerce: YAML parses an unquoted `2026-06-13` into a Date, a quoted
+        // one into a string - accept either and normalize to a Date.
+        lastReviewed: z.coerce.date().optional(),
         sources: z.array(z.string().url()).optional(),
+        // Named author for E-E-A-T; rendered as a Person in the page's JSON-LD.
+        // Optional - pages without it are attributed to the Organization.
+        author: z.string().optional(),
       }),
     }),
   }),

--- a/src/content/docs/Await Final Configuration/Configure_Await_Final_Configuration.mdx
+++ b/src/content/docs/Await Final Configuration/Configure_Await_Final_Configuration.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/setup-automated-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Await Final Configuration/What_Is_Await_Final_Configuration.md
+++ b/src/content/docs/Await Final Configuration/What_Is_Await_Final_Configuration.md
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/setup-automated-macos
+lastReviewed: 2026-06-13
 ---
 
 In the realm of Apple device management, particularly in enterprise environments, managing the configuration and deployment of devices is crucial. One of the key features to facilitate this is the “Await Final Configuration” state, which ensures that devices are properly configured before they are fully operational. This post delves into the concept of “Await Final Configuration,” its significance, and how to release a device from this state.

--- a/src/content/docs/Await Final Configuration/index.mdx
+++ b/src/content/docs/Await Final Configuration/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Await Final Configuration
+description: Understand the macOS "Await Final Configuration" state and learn how to configure it with Microsoft Intune for secure, compliant device deployment.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+"Await Final Configuration" is an Apple Device Management state that holds a Mac at the Setup Assistant until required policies are applied, ensuring devices reach the user only once they are secure and compliant. This section explains what the state does and how to configure it with Intune. It is aimed at administrators who want to guarantee a fully configured device before handing it to the end user.
+
+Read the overview first, then follow the configuration steps and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="What is Await Final Configuration?"
+    description="The Await Final Configuration state for secure, compliant setup."
+    href="/await-final-configuration/what_is_await_final_configuration/"
+  />
+  <LinkCard
+    title="Configure Await Final Configuration"
+    description="Configure the state in Intune for proper setup and compliance."
+    href="/await-final-configuration/configure_await_final_configuration/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Practical insights and considerations for Await Final Configuration."
+    href="/await-final-configuration/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/Complete Guide Macos Deployment/Add_a_Device_to_Apple_Business_Manager.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Add_a_Device_to_Apple_Business_Manager.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 3
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/setup-automated-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/Apple_Business_manager.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Apple_Business_manager.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/overview-automated-enrollment-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/Configure_MacOS_Platform_SSO.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Configure_MacOS_Platform_SSO.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 4
 sources:
   - https://learn.microsoft.com/intune/device-configuration/settings-catalog/configure-platform-sso-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/Declarative_Device_Management.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Declarative_Device_Management.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 9
 sources:
   - https://learn.microsoft.com/intune/device-updates/apple/
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/Enable_FileVault_During_the Setup_Assistant.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Enable_FileVault_During_the Setup_Assistant.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 5
 sources:
   - https://learn.microsoft.com/intune/device-configuration/endpoint-security/encrypt-filevault-macos
+lastReviewed: 2026-06-13
 ---
 
 

--- a/src/content/docs/Complete Guide Macos Deployment/Enroll_MacOS_in_Microsoft_Defender.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Enroll_MacOS_in_Microsoft_Defender.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 8
 sources:
   - https://learn.microsoft.com/defender-endpoint/mac-install-with-intune
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/Install_the_Company_Portal_app_for_MacOS_as_a_MacOS_LOB_app.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Install_the_Company_Portal_app_for_MacOS_as_a_MacOS_LOB_app.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 6
 sources:
   - https://learn.microsoft.com/intune/app-management/deployment/add-lob-macos
+lastReviewed: 2026-06-13
 ---
 
 

--- a/src/content/docs/Complete Guide Macos Deployment/Integrate_Apple_Business_Manager_with_Intune.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/Integrate_Apple_Business_Manager_with_Intune.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/setup-automated-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Complete Guide Macos Deployment/User_Experience_on_a_MacOS_Device.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/User_Experience_on_a_MacOS_Device.mdx
@@ -1,5 +1,6 @@
 ---
 title: User Experience on a MacOS Device
+description: A screenshot walkthrough of the macOS Setup Assistant enrollment experience into Intune with Platform SSO, as seen by the end user.
 sidebar:
   order: 7
 ---

--- a/src/content/docs/Complete Guide Macos Deployment/index.mdx
+++ b/src/content/docs/Complete Guide Macos Deployment/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Complete Guide Macos Deployment
+description: An end-to-end guide to deploying and enrolling macOS devices with Microsoft Intune, from Apple Business Manager to FileVault, Platform SSO, and Microsoft Defender.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This section walks through a full macOS deployment with Microsoft Intune, in the order you would build it: connecting Apple Business Manager, enrolling devices, and layering on the configuration and security policies that make up a production-ready setup. It is written for IT administrators standing up automated device enrollment (ADE) for Mac for the first time, as well as those refining an existing deployment.
+
+Follow the pages below in sequence for a complete deployment, or jump to a specific step you are working on.
+
+<CardGrid>
+  <LinkCard
+    title="Apple Business Manager"
+    description="Set up and use Apple Business Manager for efficient device management."
+    href="/complete-guide-macos-deployment/apple_business_manager/"
+  />
+  <LinkCard
+    title="Integrate Apple Business Manager with Intune"
+    description="Create an Apple MDM Push certificate and set up the ADE token."
+    href="/complete-guide-macos-deployment/integrate_apple_business_manager_with_intune/"
+  />
+  <LinkCard
+    title="Add a device to Apple Business Manager"
+    description="Add devices with Apple Configurator and sync them to Intune."
+    href="/complete-guide-macos-deployment/add_a_device_to_apple_business_manager/"
+  />
+  <LinkCard
+    title="Configure MacOS Platform SSO"
+    description="Configure Platform SSO with a Secure Enclave key during enrollment."
+    href="/complete-guide-macos-deployment/configure_macos_platform_sso/"
+  />
+  <LinkCard
+    title="Enable FileVault during the Setup Assistant"
+    description="Turn on FileVault disk encryption as part of device setup."
+    href="/complete-guide-macos-deployment/enable_filevault_during_the-setup_assistant/"
+  />
+  <LinkCard
+    title="Install the Company Portal app as a macOS LOB app"
+    description="Download, add, and assign Company Portal as a line-of-business app."
+    href="/complete-guide-macos-deployment/install_the_company_portal_app_for_macos_as_a_macos_lob_app/"
+  />
+  <LinkCard
+    title="User Experience on a MacOS Device"
+    description="A screenshot walkthrough of the end-user enrollment experience."
+    href="/complete-guide-macos-deployment/user_experience_on_a_macos_device/"
+  />
+  <LinkCard
+    title="Enroll MacOS in Microsoft Defender"
+    description="Onboard macOS devices to Microsoft Defender for Endpoint via Intune."
+    href="/complete-guide-macos-deployment/enroll_macos_in_microsoft_defender/"
+  />
+  <LinkCard
+    title="Declarative Device Management (DDM)"
+    description="Apply settings and report status asynchronously with DDM."
+    href="/complete-guide-macos-deployment/declarative_device_management/"
+  />
+  <LinkCard
+    title="Rapid Security Response"
+    description="Deliver critical security fixes to Mac between full updates."
+    href="/complete-guide-macos-deployment/rapid_security_response/"
+  />
+</CardGrid>

--- a/src/content/docs/Custom Attributes/Create_Custom_Attributes.mdx
+++ b/src/content/docs/Custom Attributes/Create_Custom_Attributes.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-management/tools/run-shell-scripts-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Custom Attributes/What_Are_Custom_Attributes.md
+++ b/src/content/docs/Custom Attributes/What_Are_Custom_Attributes.md
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-management/tools/run-shell-scripts-macos
+lastReviewed: 2026-06-13
 ---
 ## What are Custom Attributes in macOS?
 

--- a/src/content/docs/Custom Attributes/index.mdx
+++ b/src/content/docs/Custom Attributes/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Custom Attributes
+description: Learn what custom attributes are and how to create custom attribute scripts in Microsoft Intune to collect tailored data from managed macOS devices.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+Custom attributes let you collect specific information from managed macOS devices using shell scripts, extending Intune's built-in reporting and enabling richer device configuration and automation. This section explains what custom attributes are, how to build a custom attribute script, and the insights to get the most out of them. It is written for administrators who need device data beyond Intune's default inventory.
+
+Start with the concept overview, then create your first script and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="What are Custom Attributes?"
+    description="Benefits and how custom attributes enhance reporting and automation."
+    href="/custom-attributes/what_are_custom_attributes/"
+  />
+  <LinkCard
+    title="Create a Custom Attribute Script"
+    description="Build a script to collect specific information from macOS devices."
+    href="/custom-attributes/create_custom_attributes/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Best practices, use cases, and expert tips for custom attributes."
+    href="/custom-attributes/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/Declarative Device Management/Configure_Declarative_Device_Management.mdx
+++ b/src/content/docs/Declarative Device Management/Configure_Declarative_Device_Management.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-updates/apple/
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/Declarative Device Management/What_is_Declarative_Device_Management.md
+++ b/src/content/docs/Declarative Device Management/What_is_Declarative_Device_Management.md
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-updates/apple/
+lastReviewed: 2026-06-13
 ---
 *Declarative Device Management (DDM)* is a revolutionary approach to managing mobile devices that empowers them to be autonomous and proactive. One of the key advantages of DDM is improved performance and scalability. By enabling devices to operate autonomously, devices can proactively perform tasks, make decisions, and adjust configurations based on predefined rules. This not only increases efficiency but also allows for faster response times, especially in large-scale deployments.
 

--- a/src/content/docs/Declarative Device Management/index.mdx
+++ b/src/content/docs/Declarative Device Management/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Declarative Device Management
+description: Understand Declarative Device Management (DDM) on macOS and learn how to configure it with Microsoft Intune for scalable, responsive device management.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+Declarative Device Management (DDM) is an evolution of Apple's MDM protocol that lets devices apply settings and report status asynchronously, without constant polling of the management server. This improves performance, scalability, and responsiveness for managed macOS fleets. This section explains how DDM works and how to enable it with Intune.
+
+Read the concept overview first, then follow the configuration steps and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="What is Declarative Device Management?"
+    description="Learn how DDM works on macOS and the benefits it brings."
+    href="/declarative-device-management/what_is_declarative_device_management/"
+  />
+  <LinkCard
+    title="Configure Declarative Device Management"
+    description="Step-by-step guide to enabling DDM on macOS with Intune."
+    href="/declarative-device-management/configure_declarative_device_management/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Practical insights and considerations for working with DDM."
+    href="/declarative-device-management/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/Deploy Files/How_to_deploy_Files.mdx
+++ b/src/content/docs/Deploy Files/How_to_deploy_Files.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/app-management/deployment/add-unmanaged-pkg-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Deploy Files/index.mdx
+++ b/src/content/docs/Deploy Files/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Deploy Files
+description: Learn how to deploy files to macOS devices with Microsoft Intune, including the steps to follow and practical insights.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This section explains how to deploy files to managed macOS devices using Microsoft Intune, covering the deployment process and the insights to do it reliably. It is aimed at administrators who need to push configuration files, scripts, or other assets to Mac endpoints.
+
+Follow the how-to guide and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="How to deploy Files on a Mac"
+    description="Step-by-step guide to deploying files to macOS devices with Intune."
+    href="/deploy-files/how_to_deploy_files/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Practical insights for deploying files to macOS devices."
+    href="/deploy-files/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/FileVault/Enable_FileVault_in_Setup_Assistant.mdx
+++ b/src/content/docs/FileVault/Enable_FileVault_in_Setup_Assistant.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-configuration/endpoint-security/encrypt-filevault-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/FileVault/What_is_FileVault.md
+++ b/src/content/docs/FileVault/What_is_FileVault.md
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-configuration/endpoint-security/encrypt-filevault-macos
+lastReviewed: 2026-06-13
 ---
 
 FileVault is a disk encryption program available in macOS, designed to protect data by encrypting the entire drive.

--- a/src/content/docs/FileVault/index.mdx
+++ b/src/content/docs/FileVault/index.mdx
@@ -1,0 +1,32 @@
+---
+title: FileVault
+description: Learn what FileVault is and how to enable macOS full-disk encryption during the Setup Assistant with Microsoft Intune to protect data on managed Macs.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+FileVault is macOS's built-in full-disk encryption feature, protecting data at rest so it cannot be read if a device is lost or stolen. This section covers what FileVault is, how to enable it during the Setup Assistant with Intune, and the insights you need to manage encryption and recovery keys in production. It is aimed at IT administrators responsible for endpoint security and compliance on macOS.
+
+Begin with the overview, then follow the setup guide and review the field insights.
+
+<CardGrid>
+  <LinkCard
+    title="What is FileVault?"
+    description="Key features and benefits of macOS built-in disk encryption."
+    href="/filevault/what_is_filevault/"
+  />
+  <LinkCard
+    title="Enable FileVault in Setup Assistant"
+    description="Prerequisites, configuration profiles, and best practices."
+    href="/filevault/enable_filevault_in_setup_assistant/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Advanced topics, troubleshooting, and expert recommendations."
+    href="/filevault/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/Intune Getting Started Guide/Basic_Tenant_Setup.mdx
+++ b/src/content/docs/Intune Getting Started Guide/Basic_Tenant_Setup.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/methods-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Intune Getting Started Guide/Prerequisites.md
+++ b/src/content/docs/Intune Getting Started Guide/Prerequisites.md
@@ -1,10 +1,11 @@
-﻿---
+---
 title: Prerequisites
 description: Learn about the prerequisites for macOS management with Intune.
 sidebar:
     order: 1
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/overview-automated-enrollment-macos
+lastReviewed: 2026-06-13
 ---
 
 # Goals 🎯

--- a/src/content/docs/Intune Getting Started Guide/index.mdx
+++ b/src/content/docs/Intune Getting Started Guide/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Intune Getting Started Guide
+description: Get started with Microsoft Intune for macOS, covering the prerequisites and the basic tenant setup needed to begin managing Mac devices.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This guide covers the groundwork for managing macOS devices with Microsoft Intune: the prerequisites you need in place and the basic tenant configuration to get started. It is written for administrators who are new to Intune or setting up a tenant for Mac management for the first time.
+
+Begin with the prerequisites, then complete the basic tenant setup.
+
+<CardGrid>
+  <LinkCard
+    title="Prerequisites"
+    description="What you need in place before managing macOS with Intune."
+    href="/intune-getting-started-guide/prerequisites/"
+  />
+  <LinkCard
+    title="Basic Tenant Setup"
+    description="Set up a basic Intune tenant for macOS devices."
+    href="/intune-getting-started-guide/basic_tenant_setup/"
+  />
+</CardGrid>

--- a/src/content/docs/OneDrive Known Folder Move (KFM)/Configure_KFM.mdx
+++ b/src/content/docs/OneDrive Known Folder Move (KFM)/Configure_KFM.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/sharepoint/redirect-known-folders-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/OneDrive Known Folder Move (KFM)/What_is_OneDrive_KFM.mdx
+++ b/src/content/docs/OneDrive Known Folder Move (KFM)/What_is_OneDrive_KFM.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/sharepoint/redirect-known-folders-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/OneDrive Known Folder Move (KFM)/index.mdx
+++ b/src/content/docs/OneDrive Known Folder Move (KFM)/index.mdx
@@ -1,0 +1,32 @@
+---
+title: OneDrive Known Folder Move (KFM)
+description: Learn what OneDrive Known Folder Move (KFM) is and how to configure it on macOS with Microsoft Intune to redirect and back up users' key folders to OneDrive.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+OneDrive Known Folder Move (KFM) redirects users' Desktop, Documents, and other key folders into OneDrive, providing automatic cloud backup and continuity across devices on macOS. This section explains what KFM is, how to configure it with Intune, and the insights you need to avoid common pitfalls such as conflicts with iCloud sync. It is aimed at administrators rolling out OneDrive folder backup for Mac users.
+
+Read the overview first, then follow the configuration steps and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="What is OneDrive KFM?"
+    description="Learn about KFM, its benefits, and how it works on macOS."
+    href="/onedrive-known-folder-move-kfm/what_is_onedrive_kfm/"
+  />
+  <LinkCard
+    title="Configure KFM"
+    description="Step-by-step setup, best practices, and troubleshooting tips."
+    href="/onedrive-known-folder-move-kfm/configure_kfm/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Troubleshooting tips and potential conflicts with iCloud sync."
+    href="/onedrive-known-folder-move-kfm/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/Platform Single Sign-On/Browser_SSO.mdx
+++ b/src/content/docs/Platform Single Sign-On/Browser_SSO.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 3
 sources:
   - https://learn.microsoft.com/intune/device-configuration/settings-catalog/configure-platform-sso-scenarios-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/Platform Single Sign-On/Configure_PSSO.mdx
+++ b/src/content/docs/Platform Single Sign-On/Configure_PSSO.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-configuration/settings-catalog/configure-platform-sso-macos
+lastReviewed: 2026-06-13
 ---
 
 import { YouTube } from "astro-embed";

--- a/src/content/docs/Platform Single Sign-On/What_Is_PSSO.mdx
+++ b/src/content/docs/Platform Single Sign-On/What_Is_PSSO.mdx
@@ -6,6 +6,7 @@ sidebar:
 sources:
   - https://learn.microsoft.com/intune/device-configuration/enterprise-sso-plugin
   - https://learn.microsoft.com/intune/device-configuration/settings-catalog/configure-platform-sso-macos
+lastReviewed: 2026-06-13
 ---
 
 import { YouTube } from "astro-embed";

--- a/src/content/docs/Platform Single Sign-On/index.mdx
+++ b/src/content/docs/Platform Single Sign-On/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Platform Single Sign-On
+description: Learn what Platform Single Sign-On (PSSO) is and how to configure it on macOS with Microsoft Intune for seamless, secure sign-in across apps and browsers.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+Platform Single Sign-On (PSSO) lets macOS users sign in once with their Microsoft Entra ID credentials and gain seamless access across applications and browsers, while strengthening security through Secure Enclave or password-backed authentication. This section explains the concepts behind PSSO and provides step-by-step configuration guidance for IT administrators rolling it out with Intune.
+
+Start with the conceptual overview, then move on to configuration, browser SSO, and field insights.
+
+<CardGrid>
+  <LinkCard
+    title="What is PSSO?"
+    description="Authentication methods, security, and user experience explained."
+    href="/platform-single-sign-on/what_is_psso/"
+  />
+  <LinkCard
+    title="Configure PSSO"
+    description="Step-by-step setup, best practices, and troubleshooting tips."
+    href="/platform-single-sign-on/configure_psso/"
+  />
+  <LinkCard
+    title="Browser PSSO"
+    description="Configure Platform SSO for Google Chrome and Mozilla Firefox."
+    href="/platform-single-sign-on/browser_sso/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Security considerations and Secure Enclave vs. Password methods."
+    href="/platform-single-sign-on/insights_psso/"
+  />
+</CardGrid>

--- a/src/content/docs/Snippets/index.mdx
+++ b/src/content/docs/Snippets/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Snippets
+description: A collection of handy macOS management snippets for Intune admins, including packaging commands and useful shortcuts.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This section gathers short, reusable snippets that speed up everyday macOS management with Intune, from packaging commands to handy shortcuts. It is aimed at administrators who want quick reference material they can copy and adapt.
+
+Browse the snippet collections below.
+
+<CardGrid>
+  <LinkCard
+    title="Packaging"
+    description="Short commands and steps for packaging apps and payloads."
+    href="/snippets/packaging/"
+  />
+  <LinkCard
+    title="Shortcuts"
+    description="A collection of useful shortcuts for day-to-day work."
+    href="/snippets/shortcuts/"
+  />
+</CardGrid>

--- a/src/content/docs/Troubleshooting/Enrollment_Error.md
+++ b/src/content/docs/Troubleshooting/Enrollment_Error.md
@@ -1,5 +1,6 @@
 ---
 title: Enrollment Error
+description: Fix the "Your IT support doesn't allow OSX devices" macOS enrollment error in Intune by adjusting Apple device platform restrictions.
 sidebar:
   order: 1
 sources:

--- a/src/content/docs/Troubleshooting/Enrollment_Error.md
+++ b/src/content/docs/Troubleshooting/Enrollment_Error.md
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/intune/device-enrollment/apple/guide-macos
+lastReviewed: 2026-06-13
 ---
 
 When attempting to enroll a macOS device in Intune after creating an Apple MDM push certificate, 

--- a/src/content/docs/Troubleshooting/index.mdx
+++ b/src/content/docs/Troubleshooting/index.mdx
@@ -1,0 +1,22 @@
+---
+title: Troubleshooting
+description: Troubleshooting guides for common macOS management issues in Microsoft Intune, including enrollment errors and their fixes.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This section collects troubleshooting guides for common problems administrators hit when managing macOS devices with Microsoft Intune. Each guide describes the symptom and walks through the fix. It is aimed at IT administrators diagnosing enrollment and configuration issues on Mac.
+
+Browse the available guides below.
+
+<CardGrid>
+  <LinkCard
+    title="Enrollment Error"
+    description="Fix the macOS enrollment error caused by Apple device platform restrictions."
+    href="/troubleshooting/enrollment_error/"
+  />
+</CardGrid>

--- a/src/content/docs/Updating Microsoft Apps/How_to_Update_Microsoft_Apps.mdx
+++ b/src/content/docs/Updating Microsoft Apps/How_to_Update_Microsoft_Apps.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 sources:
   - https://learn.microsoft.com/microsoft-365-apps/mac/deploy-updates-for-office-for-mac
+lastReviewed: 2026-06-13
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/Updating Microsoft Apps/Insights.md
+++ b/src/content/docs/Updating Microsoft Apps/Insights.md
@@ -1,5 +1,6 @@
 ---
 title: Insights
+description: Key insights and considerations for keeping Microsoft apps updated on macOS devices managed with Intune.
 sidebar:
   order: 3
 ---

--- a/src/content/docs/Updating Microsoft Apps/Microsoft_Auto_Update.md
+++ b/src/content/docs/Updating Microsoft Apps/Microsoft_Auto_Update.md
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/microsoft-365-apps/mac/mau-preferences
+lastReviewed: 2026-06-13
 ---
 
 Microsoft Auto Update (MAU) is a tool designed to keep Microsoft applications on macOS up-to-date with the latest security patches, bug fixes, and feature improvements. It ensures that your users have access to the most recent versions of Microsoft software, enhancing both functionality and security.

--- a/src/content/docs/Updating Microsoft Apps/index.mdx
+++ b/src/content/docs/Updating Microsoft Apps/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Updating Microsoft Apps
+description: Learn how to keep Microsoft apps up to date on macOS devices with Microsoft AutoUpdate (MAU) and Microsoft Intune.
+sidebar:
+  label: Overview
+  order: 0
+lastReviewed: 2026-06-13
+---
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+Keeping Microsoft applications current on macOS is essential for security and reliability, and Microsoft AutoUpdate (MAU) is the tool that makes it possible. This section explains what MAU is and how to manage Microsoft app updates on Intune-managed Macs, including practical considerations for controlling update behavior. It is written for administrators responsible for patching and app lifecycle on macOS.
+
+Start with the how-to guide, learn how MAU works, and review the insights.
+
+<CardGrid>
+  <LinkCard
+    title="How to Update Microsoft Apps"
+    description="Update Microsoft apps on macOS using Microsoft AutoUpdate (MAU)."
+    href="/updating-microsoft-apps/how_to_update_microsoft_apps/"
+  />
+  <LinkCard
+    title="What is Microsoft Auto Update (MAU)?"
+    description="Key features of MAU and how it keeps Microsoft apps up to date."
+    href="/updating-microsoft-apps/microsoft_auto_update/"
+  />
+  <LinkCard
+    title="Insights"
+    description="Key considerations for keeping Microsoft apps updated with Intune."
+    href="/updating-microsoft-apps/insights/"
+  />
+</CardGrid>

--- a/src/content/docs/baselinesettings/antivirusconfiguration.mdx
+++ b/src/content/docs/baselinesettings/antivirusconfiguration.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 3
 sources:
   - https://learn.microsoft.com/defender-endpoint/mac-preferences
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/filevault.mdx
+++ b/src/content/docs/baselinesettings/filevault.mdx
@@ -3,6 +3,7 @@ title: FileVault
 description: How to configure FileVault for your Intune tenant.
 sources:
   - https://learn.microsoft.com/intune/device-configuration/endpoint-security/encrypt-filevault-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/mauconfiguration.mdx
+++ b/src/content/docs/baselinesettings/mauconfiguration.mdx
@@ -3,6 +3,7 @@ title: Microsoft AutoUpdate (MAU) Configuration
 description: How to configure Microsoft AutoUpdate (MAU) for your Intune tenant.
 sources:
   - https://learn.microsoft.com/microsoft-365-apps/mac/mau-preferences
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/mdeconfiguration.mdx
+++ b/src/content/docs/baselinesettings/mdeconfiguration.mdx
@@ -3,6 +3,7 @@ title: Defender for Endpoint (MDE) Configuration
 description: How to configure Defender for Endpoint (MDE) Configuration for your Intune tenant.
 sources:
   - https://learn.microsoft.com/defender-endpoint/mac-preferences
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/onedriveknownfoldermove.mdx
+++ b/src/content/docs/baselinesettings/onedriveknownfoldermove.mdx
@@ -3,6 +3,7 @@ title: OneDrive Known Folder Move
 description: How to configure OneDrive Known Folder Move for your Intune tenant.
 sources:
   - https://learn.microsoft.com/sharepoint/redirect-known-folders-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/onedriveserviceandaccess.mdx
+++ b/src/content/docs/baselinesettings/onedriveserviceandaccess.mdx
@@ -3,6 +3,7 @@ title: OneDrive Service and Access
 description: How to configure OneDrive Service and Access for your Intune tenant.
 sources:
   - https://learn.microsoft.com/sharepoint/deploy-and-configure-on-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/platformsso.mdx
+++ b/src/content/docs/baselinesettings/platformsso.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 2
 sources:
   - https://learn.microsoft.com/intune/device-configuration/settings-catalog/configure-platform-sso-macos
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";

--- a/src/content/docs/baselinesettings/updates.mdx
+++ b/src/content/docs/baselinesettings/updates.mdx
@@ -3,6 +3,7 @@ title: Software Updates
 description: How to configure Software Updates for your Intune tenant.
 sources:
   - https://learn.microsoft.com/intune/device-updates/apple/
+lastReviewed: 2026-06-13
 ---
 
 import { Steps, Aside } from "@astrojs/starlight/components";


### PR DESCRIPTION
Makes the site discoverable and citable by both traditional search and generative answer engines (ChatGPT, Perplexity, Gemini, Copilot).

## What's added
- **JSON-LD structured data** (via a Starlight `Head` override, `src/components/Head.astro`):
  - `TechArticle` + `BreadcrumbList` on all 69 doc pages
  - `Organization` + `WebSite` (+ breadcrumbs) on the home/splash pages, `sameAs` -> the GitHub repo
  - `FAQPage` with all 20 Q&A pairs on the FAQ page
  - Built from `Astro.locals.starlightRoute`; `url`/`@id` match the canonical link; `dateModified` uses `lastReviewed` if set, else the git last-updated date.
- **public/robots.txt** — allows standard crawlers and explicitly welcomes AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended, Bingbot, CCBot, and more); references the sitemap.
- **public/llms.txt** — a concise, link-rich index of the site's key sections for AI consumption (llms.txt convention), 25 curated links.
- **3 missing page descriptions** added (each feeds meta description, og:description, and JSON-LD description at once).

## Verification
- `npm run build` green (72 pages).
- JSON-LD parses as valid on all 72 pages; spot-checked home (Organization/WebSite), a doc page (TechArticle), and FAQ (FAQPage with 20 entries).
- Head override confirmed to preserve Starlight's default head (canonical, title, OG, sitemap link all intact).

## Optional follow-ups (not in this PR)
- Populate `lastReviewed` on key guides for a stronger, intentional freshness signal (ties into the docs-freshness tooling).
- Add short section landing pages (e.g. /filevault/, /troubleshooting/) — currently the bare section URLs 404; not an SEO regression (unlinked, not in sitemap) but would improve internal linking and topical authority.
- Per-author `Person` data on guides for stronger E-E-A-T (would be a content-pipeline change).