### PR TITLE
Fix sponsor logo rendering in docs; move it to top of Welcome page

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -10,6 +10,14 @@ A community hub for sharing and learning from real-world macOS experiences — g
 New here? Start with the [Getting Started guide](home/getting-started.md), or jump straight to the [Baseline Settings](baselinesettings/import.md) to configure your tenant fast.
 {% endhint %}
 
+## Our Sponsors ❤️
+
+A big thank you to our sponsor for supporting the community and helping keep these resources free.
+
+[![Devote](.gitbook/assets/devote_logo.jpg)](https://www.devote.com)
+
+[Visit Devote →](https://www.devote.com)
+
 ## Get started
 
 ### Chat with the Copilot
@@ -37,14 +45,6 @@ Quickly manage your macOS devices with curated settings from the Open Intune Bas
 - [Microsoft Mac Admins Group on LinkedIn](https://www.linkedin.com/groups/13007354/)
 - [Mac Admins Slack](https://join.slack.com/t/macadmins/shared_invite/zt-2li6s6akl-ZaR7ZVwg6Tj~8XPSUgFQ~Q)
 - [Mac Admins Software](https://macadmins.software/)
-
-## Our Sponsors ❤️
-
-A big thank you to our sponsor for supporting the community and helping keep these resources free.
-
-<a href="https://www.devote.com" target="_blank" rel="noopener noreferrer"><img src=".gitbook/assets/devote_logo.jpg" alt="Devote" width="180"></a>
-
-[Visit Devote →](https://www.devote.com)
 
 ---
 

--- a/content/home/sponsors.md
+++ b/content/home/sponsors.md
@@ -6,7 +6,7 @@ description: "A thank you to the sponsors who help keep IntuneMacAdmins free for
 
 A big thank you to our sponsor for supporting the Intune Mac Admins community and helping keep these guides, tools, and resources free for everyone.
 
-<a href="https://www.devote.com" target="_blank" rel="noopener noreferrer"><img src="../.gitbook/assets/devote_logo.jpg" alt="Devote" width="180"></a>
+[![Devote](../.gitbook/assets/devote_logo.jpg)](https://www.devote.com)
 
 [Visit Devote →](https://www.devote.com)
 


### PR DESCRIPTION
## Summary
The Devote sponsor logo was not rendering on the GitBook docs pages. GitBook does not resolve asset paths inside raw inline `<img>` tags, so the image was dropped (the link survived). Switched to GitBook-native markdown image syntax, which maps to the GitBook image CDN, and kept it clickable to devote.com.

Also moved the Welcome-page sponsor section to the top (above "Get started"), as requested.

## Changes
- `content/README.md` — sponsor section moved to the top; markdown clickable image.
- `content/home/sponsors.md` — markdown clickable image instead of raw `<img>`.

## Root cause / verification
- Confirmed on the live site that markdown images (`![](../.gitbook/assets/...)`) resolve to GitBook's `/~gitbook/image` CDN, while the raw `<img>` produced no image src at all.
- Verified via the GitBook PR preview before merge.