### PR TITLE
Update Intune release notes

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -16,6 +16,17 @@ Every meaningful documentation change, in one place. Each entry shows what was a
 
 ## July 14, 2026
 
+<!-- changelog-entry:0d6bbbef8b21d6f7 -->
+### Plan for change: Intune is moving to support macOS 15 and higher later this year
+
+**Content update** · Automatically published
+
+Microsoft Intune, the Company Portal app, and the Intune mobile device management agent will move to support macOS 15 and later, with the change occurring shortly after Apple's expected release of macOS 27 later in calendar year 2026. Devices already enrolled on macOS 14.x or below will remain enrolled, but new devices running macOS 14.x or below will be unable to enroll. Administrators can review Intune reporting under Devices and All devices, filter by macOS, and ask users to upgrade to a supported OS version.
+
+- **Published to:** [What's New in Intune](home/whats-new.md)
+- **Source:** [Microsoft Intune important notices](https://learn.microsoft.com/en-us/intune/whats-new/#plan-for-change-intune-is-moving-to-support-macos-15-and-higher-later-this-year)
+
+---
 <!-- changelog-entry:db5086e2aee1c5e6 -->
 ### The changelog moved to the main website
 

--- a/data/pipeline-state.json
+++ b/data/pipeline-state.json
@@ -251,6 +251,28 @@
       "url": "https://learn.microsoft.com/en-us/intune/whats-new/#disable-mac-address-randomization-on-macos-wi-fi-profiles",
       "week": "2026-W26"
     },
+    "9fd22e2fec54e926": {
+      "category": "announcement",
+      "firstSeen": "2026-07-14T19:20:12.692Z",
+      "meta": {
+        "notice": true,
+        "platform": "macOS"
+      },
+      "publishedAt": "2025-10-14T00:00:00.000Z",
+      "source": "ms-intune-notices",
+      "sourceName": "Microsoft Intune important notices",
+      "status": "published",
+      "summary": "Microsoft Intune, the Company Portal app, and the Intune mobile device management agent will move to support macOS 15 and later, with the change occurring shortly after Apple's expected release of macOS 27 later in calendar year 2026. Devices already enrolled on macOS 14.x or below will remain enrolled, but new devices running macOS 14.x or below will be unable to enroll. Administrators can review Intune reporting under Devices and All devices, filter by macOS, and ask users to upgrade to a supported OS version.",
+      "tags": [
+        "macos",
+        "supported os",
+        "enrollment",
+        "company portal"
+      ],
+      "title": "Plan for change: Intune is moving to support macOS 15 and higher later this year",
+      "url": "https://learn.microsoft.com/en-us/intune/whats-new/#plan-for-change-intune-is-moving-to-support-macos-15-and-higher-later-this-year",
+      "week": "2026-W29"
+    },
     "a35f3f259966c5ec": {
       "category": "configuration",
       "firstSeen": "2026-06-13T16:21:28.167Z",

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -168,6 +168,12 @@
           </div>
           <div class="release-list">
             <article class="entry">
+              <h3>Plan for change: Intune is moving to support macOS 15 and higher later this year</h3>
+              <p class="meta">Content update · Automatically published</p>
+              <p class="summary">Microsoft Intune, the Company Portal app, and the Intune mobile device management agent will move to support macOS 15 and later, with the change occurring shortly after Apple&#39;s expected release of macOS 27 later in calendar year 2026. Devices already enrolled on macOS 14.x or below will remain enrolled, but new devices running macOS 14.x or below will be unable to enroll. Administrators can review Intune reporting under Devices and All devices, filter by macOS, and ask users to upgrade to a supported OS version.</p><ul class="references"><li><strong>Published to</strong><span><a href="https://docs.intunemacadmins.com/home/whats-new" target="_blank" rel="noopener noreferrer">What&#39;s New in Intune</a></span></li><li><strong>Source</strong><span><a href="https://learn.microsoft.com/en-us/intune/whats-new/#plan-for-change-intune-is-moving-to-support-macos-15-and-higher-later-this-year" target="_blank" rel="noopener noreferrer">Microsoft Intune important notices</a></span></li></ul>
+            </article>
+
+            <article class="entry">
               <h3>The changelog moved to the main website</h3>
               <p class="meta">Site update · Maintainer published</p>
               <p class="summary">Published the source-linked changelog at <code>www.intunemacadmins.com/changelog</code>, added a Changelog button to the main landing page that opens in a new tab, and connected the static page to the same automated changelog source used by the documentation workflows.</p><ul class="references"><li><strong>Published to</strong><span><a href="https://www.intunemacadmins.com/changelog/" target="_blank" rel="noopener noreferrer">Main website changelog</a>, <a href="https://www.intunemacadmins.com/" target="_blank" rel="noopener noreferrer">IntuneMacAdmins landing page</a></span></li><li><strong>Source</strong><span><a href="https://github.com/ugurkocde/intunemacadmins" target="_blank" rel="noopener noreferrer">Documentation repository</a></span></li></ul>


### PR DESCRIPTION
Automated update from the Microsoft Intune release notes.

- Items fetched: 1 (1 new)
- Passed relevance filter: 1
- Filtered out: 0

## New items in this update

### ms-intune-notices (1)

- [Plan for change: Intune is moving to support macOS 15 and higher later this year](https://learn.microsoft.com/en-us/intune/whats-new/#plan-for-change-intune-is-moving-to-support-macos-15-and-higher-later-this-year)

---

Review checklist:

- [ ] Summaries are accurate and neutral
- [ ] No irrelevant or low-quality items slipped through
- [ ] Vercel preview renders correctly
